### PR TITLE
Experiment with Quick testing library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+build/

--- a/Landmarks.xcodeproj/project.pbxproj
+++ b/Landmarks.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		985FF2362B0DFF2E00F54BAF /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = 985FF2352B0DFF2E00F54BAF /* Quick */; };
+		985FF2392B0E000D00F54BAF /* QuickLandmarksUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985FF2382B0E000D00F54BAF /* QuickLandmarksUITests.swift */; };
 		989490072B0CE475001B6A7A /* LandmarksUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 989490062B0CE475001B6A7A /* LandmarksUITests.m */; };
 		98A2611E28B169B900FEE658 /* LandmarksApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A2611D28B169B900FEE658 /* LandmarksApp.swift */; };
 		98A2612028B169B900FEE658 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A2611F28B169B900FEE658 /* ContentView.swift */; };
@@ -45,6 +47,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		985FF2372B0E000D00F54BAF /* LandmarksUITests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "LandmarksUITests-Bridging-Header.h"; sourceTree = "<group>"; };
+		985FF2382B0E000D00F54BAF /* QuickLandmarksUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLandmarksUITests.swift; sourceTree = "<group>"; };
 		989490042B0CE475001B6A7A /* LandmarksUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LandmarksUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		989490062B0CE475001B6A7A /* LandmarksUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LandmarksUITests.m; sourceTree = "<group>"; };
 		9894900F2B0CEB2C001B6A7A /* TestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestPlan.xctestplan; sourceTree = "<group>"; };
@@ -80,6 +84,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				985FF2362B0DFF2E00F54BAF /* Quick in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -97,6 +102,8 @@
 			isa = PBXGroup;
 			children = (
 				989490062B0CE475001B6A7A /* LandmarksUITests.m */,
+				985FF2382B0E000D00F54BAF /* QuickLandmarksUITests.swift */,
+				985FF2372B0E000D00F54BAF /* LandmarksUITests-Bridging-Header.h */,
 			);
 			path = LandmarksUITests;
 			sourceTree = "<group>";
@@ -232,6 +239,9 @@
 				9894900B2B0CE475001B6A7A /* PBXTargetDependency */,
 			);
 			name = LandmarksUITests;
+			packageProductDependencies = (
+				985FF2352B0DFF2E00F54BAF /* Quick */,
+			);
 			productName = LandmarksUITests;
 			productReference = 989490042B0CE475001B6A7A /* LandmarksUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -265,6 +275,7 @@
 				TargetAttributes = {
 					989490032B0CE475001B6A7A = {
 						CreatedOnToolsVersion = 15.0.1;
+						LastSwiftMigration = 1500;
 						TestTargetID = 98A2611928B169B900FEE658;
 					};
 					98A2611928B169B900FEE658 = {
@@ -281,6 +292,9 @@
 				Base,
 			);
 			mainGroup = 98A2611128B169B900FEE658;
+			packageReferences = (
+				985FF2342B0DFF2E00F54BAF /* XCRemoteSwiftPackageReference "Quick" */,
+			);
 			productRefGroup = 98A2611B28B169B900FEE658 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -318,6 +332,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				989490072B0CE475001B6A7A /* LandmarksUITests.m in Sources */,
+				985FF2392B0E000D00F54BAF /* QuickLandmarksUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -365,6 +380,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = U3EG6EALX7;
@@ -377,6 +393,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = pl.leancode.patrol.Landmarks.LandmarksUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "LandmarksUITests/LandmarksUITests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = Landmarks;
 			};
@@ -388,6 +407,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = U3EG6EALX7;
@@ -400,6 +420,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = pl.leancode.patrol.Landmarks.LandmarksUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "LandmarksUITests/LandmarksUITests-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = Landmarks;
 			};
@@ -610,6 +632,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		985FF2342B0DFF2E00F54BAF /* XCRemoteSwiftPackageReference "Quick" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Quick/Quick.git";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		985FF2352B0DFF2E00F54BAF /* Quick */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 985FF2342B0DFF2E00F54BAF /* XCRemoteSwiftPackageReference "Quick" */;
+			productName = Quick;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 98A2611228B169B900FEE658 /* Project object */;
 }

--- a/Landmarks.xcodeproj/project.pbxproj
+++ b/Landmarks.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		985FF2362B0DFF2E00F54BAF /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = 985FF2352B0DFF2E00F54BAF /* Quick */; };
 		985FF2392B0E000D00F54BAF /* QuickLandmarksUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985FF2382B0E000D00F54BAF /* QuickLandmarksUITests.swift */; };
+		985FF23B2B0E3D9400F54BAF /* ParametrizedLandmarksUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 985FF23A2B0E3D9400F54BAF /* ParametrizedLandmarksUITests.m */; };
 		989490072B0CE475001B6A7A /* LandmarksUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 989490062B0CE475001B6A7A /* LandmarksUITests.m */; };
 		98A2611E28B169B900FEE658 /* LandmarksApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A2611D28B169B900FEE658 /* LandmarksApp.swift */; };
 		98A2612028B169B900FEE658 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A2611F28B169B900FEE658 /* ContentView.swift */; };
@@ -49,6 +50,7 @@
 /* Begin PBXFileReference section */
 		985FF2372B0E000D00F54BAF /* LandmarksUITests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "LandmarksUITests-Bridging-Header.h"; sourceTree = "<group>"; };
 		985FF2382B0E000D00F54BAF /* QuickLandmarksUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLandmarksUITests.swift; sourceTree = "<group>"; };
+		985FF23A2B0E3D9400F54BAF /* ParametrizedLandmarksUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ParametrizedLandmarksUITests.m; sourceTree = "<group>"; };
 		989490042B0CE475001B6A7A /* LandmarksUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LandmarksUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		989490062B0CE475001B6A7A /* LandmarksUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LandmarksUITests.m; sourceTree = "<group>"; };
 		9894900F2B0CEB2C001B6A7A /* TestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestPlan.xctestplan; sourceTree = "<group>"; };
@@ -104,6 +106,7 @@
 				989490062B0CE475001B6A7A /* LandmarksUITests.m */,
 				985FF2382B0E000D00F54BAF /* QuickLandmarksUITests.swift */,
 				985FF2372B0E000D00F54BAF /* LandmarksUITests-Bridging-Header.h */,
+				985FF23A2B0E3D9400F54BAF /* ParametrizedLandmarksUITests.m */,
 			);
 			path = LandmarksUITests;
 			sourceTree = "<group>";
@@ -333,6 +336,7 @@
 			files = (
 				989490072B0CE475001B6A7A /* LandmarksUITests.m in Sources */,
 				985FF2392B0E000D00F54BAF /* QuickLandmarksUITests.swift in Sources */,
+				985FF23B2B0E3D9400F54BAF /* ParametrizedLandmarksUITests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Landmarks.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Landmarks.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "quick",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Quick.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "cc96a4bd61f65798fd3f951ab1586d9d0a225c3f"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/LandmarksUITests/LandmarksUITests-Bridging-Header.h
+++ b/LandmarksUITests/LandmarksUITests-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to
+//  expose to Swift.
+//

--- a/LandmarksUITests/LandmarksUITests.m
+++ b/LandmarksUITests/LandmarksUITests.m
@@ -6,6 +6,18 @@
 
 @implementation LandmarksUITests
 
+// Called when -only-testing is specified.
++ (BOOL)instancesRespondToSelector:(SEL)aSelector {
+  NSLog(@"DBG: Called instancesRespondToSelector with arg: %@", NSStringFromSelector(aSelector));
+
+  // QUESTION: Why is this override not working?
+  // ANSWER: You were using respondsToSelector instead of instancesRespondToSelector, LOL
+
+  BOOL result = [super instancesRespondToSelector:aSelector];
+  NSLog(@"DBG: super.instancesRespondToSelector result: %@", result ? @"YES" : @"NO");
+  return result;
+}
+
 - (void)testFavorite {
   XCUIApplication *app = [[XCUIApplication alloc] init];
   [app launch];

--- a/LandmarksUITests/ParametrizedLandmarksUITests.m
+++ b/LandmarksUITests/ParametrizedLandmarksUITests.m
@@ -13,6 +13,7 @@
 - (instancetype)initWithSelector:(SEL)selector {
   // NSLog(@"Called initWithSelector with arg: %@",
   // NSStringFromSelector(selector));
+  
   return [super initWithSelector:selector];
 }
 
@@ -49,39 +50,30 @@
         (unsigned long)dartTestFiles.count);
 
   for (int i = 0; i < dartTestFiles.count; i++) {
-    /* Step 1 */
-
     NSString *name = dartTestFiles[i];
-
-    void (^anonymousFunc)(ParametrizedLandmarksUITests *) =
-        ^(ParametrizedLandmarksUITests *instance) {
-          NSLog(@"anonymousFunc called!");
-          // XCTFail(@"This is a custom message from test: %@ \n\n\n and this is
-          // a newline", name); XCTAssertTrue(NO, @"%@", @"test name is %@
-          // \n\n\n newline", name);
-        };
-
-    IMP implementation = imp_implementationWithBlock(anonymousFunc);
-    NSString *selectorStr = [NSString stringWithFormat:@"%@", name];
-    SEL selector = NSSelectorFromString(selectorStr);
-    class_addMethod(self, selector, implementation, "v@:");
-
-    /* Step 2 */
-
-    NSMethodSignature *signature =
-        [self instanceMethodSignatureForSelector:selector];
-    NSInvocation *invocation =
-        [NSInvocation invocationWithMethodSignature:signature];
-    invocation.selector = selector;
-
-    NSLog(@"RunnerUITests.testInvocations(): selectorStr = %@", selectorStr);
-
+    NSInvocation  *invocation = [self createInvocationWithName:name];
     [invocations addObject:invocation];
   }
 
   NSLog(@"After the loop");
 
   return invocations;
+}
+
++ (NSInvocation*)createInvocationWithName:(NSString *)name {
+  void (^block)(ParametrizedLandmarksUITests *) = ^(ParametrizedLandmarksUITests *instance) {
+    NSLog(@"Test method for %@ called!", name);
+  };
+  
+  IMP implementation = imp_implementationWithBlock(block);
+  NSString *selectorStr = [NSString stringWithFormat:@"test_%@", name];
+  SEL selector = NSSelectorFromString(selectorStr);
+  class_addMethod(self, selector, implementation, "v@:");
+  
+  NSMethodSignature *signature = [self instanceMethodSignatureForSelector:selector];
+  NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+  invocation.selector = selector;
+  return invocation;
 }
 
 @end

--- a/LandmarksUITests/ParametrizedLandmarksUITests.m
+++ b/LandmarksUITests/ParametrizedLandmarksUITests.m
@@ -1,0 +1,87 @@
+@import XCTest;
+@import ObjectiveC.runtime;
+
+@interface ParametrizedLandmarksUITests : XCTestCase
+@end
+
+@implementation ParametrizedLandmarksUITests
+//- (instancetype)init {
+//  NSLog(@"Called init");
+//  return [super init];
+//}
+//
+- (instancetype)initWithSelector:(SEL)selector {
+  // NSLog(@"Called initWithSelector with arg: %@",
+  // NSStringFromSelector(selector));
+  return [super initWithSelector:selector];
+}
+
+// Called when running all tests
++ (XCTestSuite *)defaultTestSuite {
+  NSLog(@"DBG: Called defaultTestSuite");
+  // NSLog(@"DBG: %@", NSThread.callStackSymbols);
+  return [super defaultTestSuite];
+}
+
+// Called when -only-testing is specified.
++ (BOOL)instancesRespondToSelector:(SEL)aSelector {
+  NSLog(@"DBG: Called instancesRespondToSelector with arg: %@",
+        NSStringFromSelector(aSelector));
+  // NSLog(@"DBG: %@", NSThread.callStackSymbols);
+
+  return [super respondsToSelector:aSelector];
+}
+
++ (NSArray<NSInvocation *> *)testInvocations {
+  NSLog(@"DBG: testInvocations() called");
+  // NSLog(@"DBG: %@", NSThread.callStackSymbols);
+
+  /* Prepare dummy input */
+  __block NSMutableArray<NSString *> *dartTestFiles =
+      [[NSMutableArray alloc] init];
+  [dartTestFiles addObject:@"example_test"];
+  [dartTestFiles addObject:@"permissions_location_test"];
+  [dartTestFiles addObject:@"permissions_many_test"];
+
+  NSMutableArray<NSInvocation *> *invocations = [[NSMutableArray alloc] init];
+
+  NSLog(@"Before the loop, %lu elements in the array",
+        (unsigned long)dartTestFiles.count);
+
+  for (int i = 0; i < dartTestFiles.count; i++) {
+    /* Step 1 */
+
+    NSString *name = dartTestFiles[i];
+
+    void (^anonymousFunc)(ParametrizedLandmarksUITests *) =
+        ^(ParametrizedLandmarksUITests *instance) {
+          NSLog(@"anonymousFunc called!");
+          // XCTFail(@"This is a custom message from test: %@ \n\n\n and this is
+          // a newline", name); XCTAssertTrue(NO, @"%@", @"test name is %@
+          // \n\n\n newline", name);
+        };
+
+    IMP implementation = imp_implementationWithBlock(anonymousFunc);
+    NSString *selectorStr = [NSString stringWithFormat:@"%@", name];
+    SEL selector = NSSelectorFromString(selectorStr);
+    class_addMethod(self, selector, implementation, "v@:");
+
+    /* Step 2 */
+
+    NSMethodSignature *signature =
+        [self instanceMethodSignatureForSelector:selector];
+    NSInvocation *invocation =
+        [NSInvocation invocationWithMethodSignature:signature];
+    invocation.selector = selector;
+
+    NSLog(@"RunnerUITests.testInvocations(): selectorStr = %@", selectorStr);
+
+    [invocations addObject:invocation];
+  }
+
+  NSLog(@"After the loop");
+
+  return invocations;
+}
+
+@end

--- a/LandmarksUITests/ParametrizedLandmarksUITests.m
+++ b/LandmarksUITests/ParametrizedLandmarksUITests.m
@@ -5,17 +5,6 @@
 @end
 
 @implementation ParametrizedLandmarksUITests
-//- (instancetype)init {
-//  NSLog(@"Called init");
-//  return [super init];
-//}
-//
-- (instancetype)initWithSelector:(SEL)selector {
-  // NSLog(@"Called initWithSelector with arg: %@",
-  // NSStringFromSelector(selector));
-  
-  return [super initWithSelector:selector];
-}
 
 // Called when running all tests
 + (XCTestSuite *)defaultTestSuite {

--- a/LandmarksUITests/ParametrizedLandmarksUITests.m
+++ b/LandmarksUITests/ParametrizedLandmarksUITests.m
@@ -71,10 +71,9 @@ static NSString *_selectedTest = nil;
   };
   
   IMP implementation = imp_implementationWithBlock(block);
-  // NSString *selectorStr = [NSString stringWithFormat:@"test_%@", name];
   SEL selector = NSSelectorFromString(name);
   class_addMethod(self, selector, implementation, "v@:");
-  
+
   NSMethodSignature *signature = [self instanceMethodSignatureForSelector:selector];
   NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
   invocation.selector = selector;

--- a/LandmarksUITests/QuickLandmarksUITests.swift
+++ b/LandmarksUITests/QuickLandmarksUITests.swift
@@ -1,0 +1,16 @@
+import Quick
+import XCTest
+
+class QuickLandmarksUITests: QuickSpec {
+  override class func spec() {
+    it("testA") {
+      NSLog("Executed test A")
+      XCTAssertTrue(true)
+    }
+
+    it("testB") {
+      NSLog("Executed test B")
+      XCTAssertTrue(true)
+    }
+  }
+}

--- a/LandmarksUITests/QuickLandmarksUITests.swift
+++ b/LandmarksUITests/QuickLandmarksUITests.swift
@@ -2,6 +2,11 @@ import Quick
 import XCTest
 
 class QuickLandmarksUITests: QuickSpec {
+  override class func instancesRespond(to aSelector: Selector!) -> Bool {
+    NSLog("instancesRespondTo: \(aSelector)")
+    return super.instancesRespond(to: aSelector)
+  }
+  
   override class func spec() {
     it("testA") {
       NSLog("Executed test A")
@@ -14,3 +19,4 @@ class QuickLandmarksUITests: QuickSpec {
     }
   }
 }
+


### PR DESCRIPTION
### Intro

With this PR, I'm aiming to verify whether the `-only-testing` flag of the `xcodebuild test` command works with the [Quick](https://github.com/Quick/Quick) testing library. The [Quick testing library](https://github.com/Quick/Quick/blob/cc96a4bd61f65798fd3f951ab1586d9d0a225c3f/Sources/QuickObjectiveC/QuickSpec.h#L3-L30) works by using [`XCTestCase.testInvocations`](https://developer.apple.com/documentation/xctest/xctestcase/1496271-testinvocations) API to generate test methods dynamically at runtime.

[Patrol does the same thing](https://github.com/leancodepl/patrol/blob/3379ff952eb8f78f3183b929f6d19dbe4ab8a792/packages/patrol/ios/Classes/PatrolIntegrationTestRunner.h#L18) - it also uses `XCTestCase.testInvocations` to generate test methods dynamically at runtime.

### Result

**Success**

Meaning: it is possible to select a single _dynamically generated_ test (written in Quick) using `xcodebuild test`'s `-only-testing` option.

### Check if yourself

Clone this repo, checkout this branch, then build:

```
xcodebuild build-for-testing \
  -scheme Landmarks \
  -configuration Debug \
  -sdk iphonesimulator \
  -destination 'generic/platform=iOS Simulator' \
  -derivedDataPath build/ios_integ \
  -quiet
```

and run:

```
xcodebuild test-without-building \
  -xctestrun build/ios_integ/Build/Products/Landmarks_TestPlan_iphonesimulator17.0-arm64-x86_64.xctestrun \
  -only-testing 'LandmarksUITests/QuickLandmarksUITests/testA' \
  -destination 'platform=iOS Simulator,name=iPhone 15' \
  -resultBundlePath "build/ios_results_$(date +%s).xcresult"
```


Notice that a single test was executed.